### PR TITLE
[WIP] Add `as_taskerr` machinery to reduce unwraps in workflows

### DIFF
--- a/src/tascii/src/lib.rs
+++ b/src/tascii/src/lib.rs
@@ -35,7 +35,7 @@ use std::{
 pub mod prelude {
     pub use crate::task_trait::{AsyncRunnable, Runnable, TaskIdentifier};
 
-    pub use crate::workflows::{Context, TaskError};
+    pub use crate::workflows::{Context, TaskError, ToTaskError};
 
     pub use crate::runtime::Runtime;
 

--- a/src/tascii/src/workflows.rs
+++ b/src/tascii/src/workflows.rs
@@ -67,6 +67,16 @@ impl From<anyhow::Error> for TaskError {
     }
 }
 
+pub trait ToTaskError<T> {
+    fn as_taskerr(self) -> Result<T, TaskError>;
+}
+
+impl<T, E: Into<TaskError>> ToTaskError<T> for Result<T, E> {
+    fn as_taskerr(self) -> Result<T, TaskError> {
+        self.map_err(|e| e.into())
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct InternalError {
     internal: Option<&'static str>,

--- a/src/workflows/src/deploy_booking/deploy_host.rs
+++ b/src/workflows/src/deploy_booking/deploy_host.rs
@@ -52,7 +52,7 @@ impl AsyncRunnable for DeployHost {
 
         let mut mock_waiter = Mailbox::set_endpoint_hook(self.using_instance, "mock")
             .await
-            .unwrap();
+            .as_taskerr()?;
 
         self.using_instance
             .log(
@@ -100,23 +100,23 @@ impl AsyncRunnable for DeployHost {
 
         let mut preimage_waiter = Mailbox::set_endpoint_hook(self.using_instance, "pre_image")
             .await
-            .unwrap();
+            .as_taskerr()?;
 
         let mut imaging_waiter = Mailbox::set_endpoint_hook(self.using_instance, "post_image")
             .await
-            .unwrap();
+            .as_taskerr()?;
 
         let mut post_boot_waiter = Mailbox::set_endpoint_hook(self.using_instance, "post_boot")
             .await
-            .unwrap();
+            .as_taskerr()?;
 
         let mut post_provision_waiter =
             Mailbox::set_endpoint_hook(self.using_instance, "post_provision")
                 .await
-                .unwrap();
+            .as_taskerr()?;
 
-        let mut client = new_client().await.unwrap();
-        let mut transaction = client.easy_transaction().await.unwrap();
+        let mut client = new_client().await.as_taskerr()?;
+        let mut transaction = client.easy_transaction().await.as_taskerr()?;
 
         let aggregate = self
             .aggregate_id


### PR DESCRIPTION
Adds machinery to reduce how much LaaSRL uses `unwrap` in the various workflows.

This does come with the side effect that tracebacks for these cases are no longer collected, however this could be mitigated by making `as_taskerr` return a type that can be told to collect a backtrace and put that into the log.

WIP, as neither have any significant portion of the panics in the workflows been replaced nor is the trait itself likely in any final form